### PR TITLE
Taxi meter

### DIFF
--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -78,8 +78,8 @@ describe TaxiMeter do
       #stops time to simulate end of trip
       @meter.stop
 
-      #sets miles driven to exactly 1/6 mile
-      @meter.miles_driven = 1.0 / 6.0
+      #sets miles driven to less than 1/6 mile
+      @meter.miles_driven = 0.04
 
       # calculates price by miles driven expects inital 2.50 charge
       expect(@meter.amount_due).to eq(250)
@@ -107,7 +107,7 @@ describe TaxiMeter do
       @meter.miles_driven = 0
 
       #exect amout due to caluclate cost based on time
-      expect(@meter.amount_due).to eq(2009)
+      expect(@meter.amount_due).to eq(2232)
     end
   end
 
@@ -152,6 +152,6 @@ describe TaxiMeter do
       meter.stop
 
       #exect amout due to caluclate cost based on time
-      expect(meter.amount_due).to eq(149)
+      expect(meter.amount_due).to eq(399)
     end
 end

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -108,6 +108,23 @@ describe TaxiMeter do
       #exect amout due to caluclate cost based on time
       expect(@meter.amount_due).to eq(2009)
     end
+
+    it "charges an additional $1 if start time is between 9pm and 4am" do
+      #stub time for testing reseting start time
+      Time.stub(:now).and_return(Time.parse('12am'))
+
+      #reset @start_time
+      @meter.start
+
+      #stub time for testing stop_time
+      Time.stub(:now).and_return(@start_time + (1 * 60))
+
+      #end the trip
+      @meter.stop
+
+      #exect amout due to caluclate cost based on time
+      expect(@meter.amount_due).to eq(149)
+    end
   end
 
 

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -73,7 +73,16 @@ describe TaxiMeter do
       @meter.start
     end
 
-    it "charges $2.50 for the first 1/6 mile (recorded in cents)"
+    it "charges $2.50 for the first 1/6 mile (recorded in cents)" do
+      #stops time to simulate end of trip
+      @meter.stop
+
+      #sets miles driven to exactly 1/6 mile
+      @meter.miles_driven = 0.166666667
+
+      # calculates price by miles driven expects inital 2.50 charge
+      expect(@meter.amount_due).to eq(250)
+    end
   end
 
 
@@ -89,5 +98,5 @@ describe TaxiMeter do
 
     it "has a minimum fare of $13.10"
   end
-
 end
+

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -41,7 +41,26 @@ describe TaxiMeter do
       expect(@meter.start_time).to eq(start_time)
     end
 
-    it "records the time it stopped"
+    it "records the time it stopped" do
+      #starts meter
+      @meter.start
+
+      #stubs time to add 15 minutes
+      later = @meter.start_time + (15 * 60)
+      Time.stub(:now).and_return(later)
+
+      #stops meter using stubbed time
+      @meter.stop
+
+      #restub time to even later
+      much_later = @meter.start_time + (30 * 60)
+      Time.stub(:now).and_return(much_later)
+
+      #stop_time should reflect stopped time
+      expect(@meter.stop_time).to eq(later)
+      expect(@meter.stop_time).to_not eq(@meter.start_time)
+      expect(@meter.stop_time).to_not eq(much_later)
+    end
   end
 
   context "The taxi meter starts" do

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -96,7 +96,22 @@ describe TaxiMeter do
       @meter.start
     end
 
-    it "has a minimum fare of $13.10"
+    it "has a minimum fare of $13.10" do
+      #stops time to simulate end of trip
+      @meter.stop
+
+      #sets milage to a small amount
+      @meter.miles_driven = 3
+
+      #calculates price based on miles expects airport minimum
+      expect(@meter.amount_due).to eq(1310)
+
+      # #sets milage to a large amount
+      # @meter.miles_driven = 20
+
+      # #calculates price based on miles expects normal fare
+      # expect(@meter.amount_due).to eq(###)
+    end
   end
 end
 

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -92,7 +92,7 @@ describe TaxiMeter do
       @meter.miles_driven = 30.854
 
       #calculates price by miles driven
-      expect(@meter.amount_due).to eq(7400)
+      expect(@meter.amount_due).to eq(7650)
     end
   end
 

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -78,15 +78,27 @@ describe TaxiMeter do
       @meter.stop
 
       #sets miles driven to exactly 1/6 mile
-      @meter.miles_driven = 0.166666667
+      @meter.miles_driven = 1.0 / 6.0
 
       # calculates price by miles driven expects inital 2.50 charge
       expect(@meter.amount_due).to eq(250)
+    end
+
+    it "charges $2.40 a miles prorated by 1/6" do
+      #stops time to simulate end of trip
+      @meter.stop_time
+
+      #sets miles driven to number greater than min and not a whole number
+      @meter.miles_driven = 30.854
+
+      #calculates price by miles driven
+      expect(@meter.amount_due).to eq(7400)
     end
   end
 
 
   context "The taxi meter starts from ABIA" do
+
     before do
       # We want to freeze time to the point when the meter starts
       start_time = Time.now

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -1,5 +1,164 @@
+# require './taxi_meter.rb'
+# require 'time'
+
+# describe TaxiMeter do
+
+#   def one_sixth
+#     1.0 / 6.0
+#   end
+
+#   describe "Basic functionality" do
+
+#     before do
+#       @meter = TaxiMeter.new
+#     end
+
+#     it "starts at zero" do
+#       expect(@meter.amount_due).to eq(0)
+#       expect(@meter.miles_driven).to eq(0)
+#     end
+
+#     it "can start and stop" do
+#       @meter.start
+#       expect(@meter.start_time).to_not be_nil
+#       expect(@meter.stop_time).to be_nil
+
+#       @meter.stop
+#       expect(@meter.stop_time).to_not be_nil
+#     end
+
+#     it "records the time it started" do
+#       # We want to freeze time to the point when the meter starts
+#       start_time = Time.now
+#       Time.stub(:now).and_return(start_time)
+
+#       # This should grab the current time
+#       @meter.start
+
+#       # Re-stub Time to be 5 minutes into the future
+#       Time.stub(:now).and_return(start_time + 5 * 60)
+
+#       # Once started, start_time shouldn't rely on the current time
+#       expect(@meter.start_time).to eq(start_time)
+#     end
+
+#     it "records the time it stopped" do
+#       #starts meter
+#       @meter.start
+
+#       #stubs time to add 15 minutes
+#       later = @meter.start_time + (15 * 60)
+#       Time.stub(:now).and_return(later)
+
+#       #stops meter using stubbed time
+#       @meter.stop
+
+#       #restub time to even later
+#       much_later = @meter.start_time + (30 * 60)
+#       Time.stub(:now).and_return(much_later)
+
+#       #stop_time should reflect stopped time
+#       expect(@meter.stop_time).to eq(later)
+#       expect(@meter.stop_time).to_not eq(@meter.start_time)
+#       expect(@meter.stop_time).to_not eq(much_later)
+#     end
+#   end
+
+#   context "The taxi meter starts" do
+#     before do
+#       # We want to freeze time to the point when the meter starts
+#       @start_time = Time.parse('11am', Time.now)
+#       Time.stub(:now).and_return(@start_time)
+
+#       @meter = TaxiMeter.new
+#       @meter.start
+#     end
+
+#     it "charges $2.50 for the first 1/6 mile (recorded in cents)" do
+#       #stops time to simulate end of trip
+#       @meter.stop
+
+#       #sets miles driven to less than 1/6 mile
+#       @meter.miles_driven = 0.04
+
+#       # calculates price by miles driven expects inital 2.50 charge
+#       expect(@meter.amount_due).to eq(250)
+#     end
+
+#     it "charges $2.40 a miles prorated by 1/6" do
+#       #stops time to simulate end of trip
+#       @meter.stop
+
+#       #sets miles driven to number greater than min and not a whole number
+#       @meter.miles_driven = 30.854
+
+#       #calculates price by miles driven
+#       expect(@meter.amount_due).to eq(7650)
+#     end
+
+#     it "charges $29.00 an hour prorate by minute" do
+#       #stub time for testing stop_time
+#       Time.stub(:now).and_return(@start_time + (40.5 * 60))
+
+#       #end the trip
+#       @meter.stop
+
+#       #sets miles driven to 0
+#       @meter.miles_driven = 0
+
+#       #exect amout due to caluclate cost based on time
+#       expect(@meter.amount_due).to eq()
+#     end
+#   end
+
+
+#   context "The taxi meter starts from ABIA" do
+
+#     before do
+#       # We want to freeze time to the point when the meter starts
+#       start_time = Time.now
+#       Time.stub(:now).and_return(start_time)
+
+#       @meter = TaxiMeter.new(airport: true)
+#       @meter.start
+#     end
+
+#     it "has a minimum fare of $13.10" do
+#       #stops time to simulate end of trip
+#       @meter.stop
+
+#       #sets milage to a small amount
+#       @meter.miles_driven = 3
+
+#       #calculates price based on miles expects airport minimum
+#       expect(@meter.amount_due).to eq(1310)
+#     end
+#   end
+#     it "charges an additional $1 if start time is between 9pm and 4am" do
+#       meter = TaxiMeter.new
+
+#       now = Time.now
+
+#       #stub time for testing reseting start time
+#       Time.stub(:now).and_return(Time.parse('3 am', now))
+
+#       #reset @start_time
+#       meter.start
+
+#       #stub time for testing stop_time
+#       Time.stub(:now).and_return(meter.start_time + (1 * 60))
+
+#       #end the trip
+#       meter.stop
+
+#       #exect amout due to caluclate cost based on time
+#       expect(meter.amount_due).to eq(399)
+#     end
+# end
+
+
 require './taxi_meter.rb'
-require 'time'
+require 'pry-debugger'
 
 describe TaxiMeter do
 
@@ -13,9 +172,22 @@ describe TaxiMeter do
       @meter = TaxiMeter.new
     end
 
-    it "starts at zero" do
-      expect(@meter.amount_due).to eq(0)
-      expect(@meter.miles_driven).to eq(0)
+    it "starts at zero miles driven" do
+      expect(@meter.miles_driven).to eq 0
+    end
+
+    # it "cannot set amount due" do
+    #   expect { @meter.amount = 99 }.to raise_error
+    # end
+
+    # it "cannot set start time nor stop time" do
+    #   expect { @meter.start_time = Time.now }.to raise_error
+    #   expect { @meter.stop_time = Time.now }.to raise_error
+    # end
+
+    it "can specify miles driven" do
+      @meter.miles_driven = 5
+      expect(@meter.miles_driven).to eq 5
     end
 
     it "can start and stop" do
@@ -29,7 +201,7 @@ describe TaxiMeter do
 
     it "records the time it started" do
       # We want to freeze time to the point when the meter starts
-      start_time = Time.now
+      start_time = Time.parse('1:00pm')
       Time.stub(:now).and_return(start_time)
 
       # This should grab the current time
@@ -43,31 +215,46 @@ describe TaxiMeter do
     end
 
     it "records the time it stopped" do
-      #starts meter
+      # Explicitly set a start time
+      start_time = Time.parse('1:00pm')
+      Time.stub(:now).and_return(start_time)
+
       @meter.start
 
-      #stubs time to add 15 minutes
-      later = @meter.start_time + (15 * 60)
-      Time.stub(:now).and_return(later)
+      # Re-stub Time to be 5 minutes into the future
+      end_time = start_time + 5 * 60
+      Time.stub(:now).and_return(end_time)
 
-      #stops meter using stubbed time
+      # Stop time should be what we stubbed
+      @meter.stop
+      expect(@meter.stop_time).to eq(end_time)
+    end
+
+    it "doesn't change amount due after it stops" do
+      # Explicitly set a start time
+      start_time = Time.parse('1:00pm')
+      Time.stub(:now).and_return(start_time)
+      @meter.start
+
+      # Re-stub Time to be 5 minutes into the future
+      end_time = start_time + 5 * 60
+      Time.stub(:now).and_return(end_time)
       @meter.stop
 
-      #restub time to even later
-      much_later = @meter.start_time + (30 * 60)
-      Time.stub(:now).and_return(much_later)
+      amount_due_at_stop = @meter.amount_due
 
-      #stop_time should reflect stopped time
-      expect(@meter.stop_time).to eq(later)
-      expect(@meter.stop_time).to_not eq(@meter.start_time)
-      expect(@meter.stop_time).to_not eq(much_later)
+      # Re-stub Time to be 30 minutes into the future
+      Time.stub(:now).and_return(end_time + 30 * 60)
+
+      # The amount due should not increase
+      expect(@meter.amount_due).to eq(amount_due_at_stop)
     end
   end
 
-  context "The taxi meter starts" do
+  context "The taxi meter starts during normal hours" do
     before do
       # We want to freeze time to the point when the meter starts
-      @start_time = Time.parse('11am', Time.now)
+      @start_time = Time.parse('1:00pm')
       Time.stub(:now).and_return(@start_time)
 
       @meter = TaxiMeter.new
@@ -75,83 +262,128 @@ describe TaxiMeter do
     end
 
     it "charges $2.50 for the first 1/6 mile (recorded in cents)" do
-      #stops time to simulate end of trip
-      @meter.stop
-
-      #sets miles driven to less than 1/6 mile
-      @meter.miles_driven = 0.04
-
-      # calculates price by miles driven expects inital 2.50 charge
-      expect(@meter.amount_due).to eq(250)
+      @meter.miles_driven = one_sixth
+      expect(@meter.amount_due).to eq 250
     end
 
-    it "charges $2.40 a miles prorated by 1/6" do
-      #stops time to simulate end of trip
-      @meter.stop
-
-      #sets miles driven to number greater than min and not a whole number
-      @meter.miles_driven = 30.854
-
-      #calculates price by miles driven
-      expect(@meter.amount_due).to eq(7650)
+    it "assumes the taxi is going to drive an distance greater than zero" do
+      expect(@meter.amount_due).to eq 250
     end
 
-    it "charges $29.00 an hour prorate by minute" do
-      #stub time for testing stop_time
-      Time.stub(:now).and_return(@start_time + (40.5 * 60))
+    it "charges $2.40 per mile afterwards, prorated by each 1/6 mile" do
+      @meter.miles_driven = 1 + one_sixth
+      expect(@meter.amount_due).to eq 490
 
-      #end the trip
-      @meter.stop
+      @meter.miles_driven = 1 + one_sixth + 0.01
+      expect(@meter.amount_due).to eq 530
 
-      #sets miles driven to 0
-      @meter.miles_driven = 0
+      @meter.miles_driven = 1 + (one_sixth * 2)
+      expect(@meter.amount_due).to eq 530
 
-      #exect amout due to caluclate cost based on time
-      expect(@meter.amount_due).to eq(2232)
+      @meter.miles_driven = 1 + (one_sixth * 3)
+      expect(@meter.amount_due).to eq 570
+    end
+
+    it "charges $29.00 per hour, prorated by minute" do
+      # Test 30 minutes later
+      Time.stub(:now).and_return(@start_time + 30 * 60)
+      expect(@meter.amount_due).to eq(250 + (2900 / 2))
+
+      # Test 29.5 minutes later
+      Time.stub(:now).and_return(@start_time + 30 * 60 - 0.5)
+      expect(@meter.amount_due).to eq(250 + (2900 / 2))
+
+      # Test 60 minutes later
+      Time.stub(:now).and_return(@start_time + 60 * 60)
+      expect(@meter.amount_due).to eq(250 + 2900)
+
+      # Test 19 hours later
+      Time.stub(:now).and_return(@start_time + 19 * 60 * 60)
+      expect(@meter.amount_due).to eq(250 + (2900 * 19))
+    end
+
+    it "charges for both distance and time" do
+      # 120 minutes, 2 1/6 miles
+      Time.stub(:now).and_return(@start_time + 2 * 60 * 60)
+      @meter.miles_driven = 2 + one_sixth
+      expect(@meter.amount_due).to eq(250 + 240*2 + 2900*2)
+
+      # 14 minutes, just over 3/6 miles (counted at 4/6 miles)
+      Time.stub(:now).and_return(@start_time + 14 * 60)
+      @meter.miles_driven = one_sixth * 3 + 0.01
+      expect(@meter.amount_due).to eq(250 + 240/2 + 677)
+    end
+  end
+
+
+  it "charges an extra $1 between 9pm and 4am" do
+    7.times do |n|
+      Time.stub(:now).and_return(Time.parse('9:15pm') + n * 60 * 60)
+      meter = TaxiMeter.new
+      meter.start
+      # We wrap our amount in an array to make it easier to debug which hour n is
+      expect([n, meter.amount_due]).to eq [n, 350]
     end
   end
 
 
   context "The taxi meter starts from ABIA" do
-
     before do
       # We want to freeze time to the point when the meter starts
-      start_time = Time.now
-      Time.stub(:now).and_return(start_time)
+      @start_time = Time.parse('1:00pm')
+      Time.stub(:now).and_return(@start_time)
 
       @meter = TaxiMeter.new(airport: true)
       @meter.start
     end
 
     it "has a minimum fare of $13.10" do
-      #stops time to simulate end of trip
-      @meter.stop
+      expect(@meter.amount_due).to eq 1310
 
-      #sets milage to a small amount
-      @meter.miles_driven = 3
+      # 2 1/6 miles drives is only 250 + 480
+      @meter.miles_driven = 2 + one_sixth
+      expect(@meter.amount_due).to eq 1310
 
-      #calculates price based on miles expects airport minimum
-      expect(@meter.amount_due).to eq(1310)
+      # 10 minutes is only 250 + 290
+      @meter.miles_driven = 0
+      Time.stub(:now).and_return(@start_time + 10 * 60)
+      expect(@meter.amount_due).to eq 1310
+    end
+
+    it "charges correctly when the total fare is over $13.10" do
+      # 2 2/6 miles and 15 minutes is 250 + 520 + 725 = 1495
+      @meter.miles_driven = 2 + (2 * one_sixth)
+      Time.stub(:now).and_return(@start_time + 15 * 60)
+      expect(@meter.amount_due).to eq 1495
     end
   end
-    it "charges an additional $1 if start time is between 9pm and 4am" do
-      meter = TaxiMeter.new
 
-      now = Time.now
 
-      #stub time for testing reseting start time
-      Time.stub(:now).and_return(Time.parse('3 am', now))
+  context "The taxi meter starts from ABIA after 9pm" do
+    before do
+      # We want to freeze time to the point when the meter starts
+      @start_time = Time.parse('10:00pm')
+      Time.stub(:now).and_return(@start_time)
 
-      #reset @start_time
-      meter.start
-
-      #stub time for testing stop_time
-      Time.stub(:now).and_return(meter.start_time + (1 * 60))
-
-      #end the trip
-      meter.stop
-
-      #exect amout due to caluclate cost based on time
-      expect(meter.amount_due).to eq(399)
+      @meter = TaxiMeter.new(airport: true)
+      @meter.start
     end
+
+    it "has a minimum fare of $13.10" do
+      expect(@meter.amount_due).to eq 1310
+
+      # 10 minutes is only 100 + 250 + 290
+      @meter.miles_driven = 0
+      Time.stub(:now).and_return(@start_time + 10 * 60)
+      expect(@meter.amount_due).to eq 1310
+    end
+
+    it "charges correctly when the total fare is over $13.10" do
+      # 1 1/6 miles and 15 minutes is 250 + 240 + 725 + 100 = 1410
+      @meter.miles_driven = 1 + one_sixth
+      Time.stub(:now).and_return(@start_time + 15 * 60)
+      expect(@meter.amount_due).to eq 1315
+    end
+  end
+
 end

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -97,7 +97,7 @@ describe TaxiMeter do
 
     it "charges $29.00 an hour prorate by minute" do
       #stub time for testing stop_time
-      Time.stub(:now).and_return(@start_time + (40 * 60))
+      Time.stub(:now).and_return(@start_time + (40.5 * 60))
 
       #end the trip
       @meter.stop
@@ -106,7 +106,7 @@ describe TaxiMeter do
       @meter.miles_driven = 0
 
       #exect amout due to caluclate cost based on time
-      expect(@meter.amount_due).to eq(1960)
+      expect(@meter.amount_due).to eq(2009)
     end
   end
 

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -86,13 +86,27 @@ describe TaxiMeter do
 
     it "charges $2.40 a miles prorated by 1/6" do
       #stops time to simulate end of trip
-      @meter.stop_time
+      @meter.stop
 
       #sets miles driven to number greater than min and not a whole number
       @meter.miles_driven = 30.854
 
       #calculates price by miles driven
       expect(@meter.amount_due).to eq(7650)
+    end
+
+    it "charges $29.00 an hour prorate by minute" do
+      #stub time for testing stop_time
+      Time.stub(:now).and_return(@start_time + (40 * 60))
+
+      #end the trip
+      @meter.stop
+
+      #sets miles driven to 0
+      @meter.miles_driven = 0
+
+      #exect amout due to caluclate cost based on time
+      expect(@meter.amount_due).to eq(1960)
     end
   end
 

--- a/spec/taxi_meter_spec.rb
+++ b/spec/taxi_meter_spec.rb
@@ -1,4 +1,5 @@
 require './taxi_meter.rb'
+require 'time'
 
 describe TaxiMeter do
 
@@ -13,8 +14,8 @@ describe TaxiMeter do
     end
 
     it "starts at zero" do
-      @meter.amount_due = 0
-      @meter.miles_driven = 0
+      expect(@meter.amount_due).to eq(0)
+      expect(@meter.miles_driven).to eq(0)
     end
 
     it "can start and stop" do
@@ -66,7 +67,7 @@ describe TaxiMeter do
   context "The taxi meter starts" do
     before do
       # We want to freeze time to the point when the meter starts
-      @start_time = Time.now
+      @start_time = Time.parse('11am', Time.now)
       Time.stub(:now).and_return(@start_time)
 
       @meter = TaxiMeter.new
@@ -108,23 +109,6 @@ describe TaxiMeter do
       #exect amout due to caluclate cost based on time
       expect(@meter.amount_due).to eq(2009)
     end
-
-    it "charges an additional $1 if start time is between 9pm and 4am" do
-      #stub time for testing reseting start time
-      Time.stub(:now).and_return(Time.parse('12am'))
-
-      #reset @start_time
-      @meter.start
-
-      #stub time for testing stop_time
-      Time.stub(:now).and_return(@start_time + (1 * 60))
-
-      #end the trip
-      @meter.stop
-
-      #exect amout due to caluclate cost based on time
-      expect(@meter.amount_due).to eq(149)
-    end
   end
 
 
@@ -148,13 +132,26 @@ describe TaxiMeter do
 
       #calculates price based on miles expects airport minimum
       expect(@meter.amount_due).to eq(1310)
-
-      # #sets milage to a large amount
-      # @meter.miles_driven = 20
-
-      # #calculates price based on miles expects normal fare
-      # expect(@meter.amount_due).to eq(###)
     end
   end
-end
+    it "charges an additional $1 if start time is between 9pm and 4am" do
+      meter = TaxiMeter.new
 
+      now = Time.now
+
+      #stub time for testing reseting start time
+      Time.stub(:now).and_return(Time.parse('3 am', now))
+
+      #reset @start_time
+      meter.start
+
+      #stub time for testing stop_time
+      Time.stub(:now).and_return(meter.start_time + (1 * 60))
+
+      #end the trip
+      meter.stop
+
+      #exect amout due to caluclate cost based on time
+      expect(meter.amount_due).to eq(149)
+    end
+end

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -21,5 +21,12 @@ class TaxiMeter
   def stop
     @stop_time = Time.now
   end
+
+  def amount_due
+    if @miles_driven >= 0.166666667
+      @amount_due += 250
+    end
+      @amount_due
+  end
 end
 

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -24,7 +24,7 @@ class TaxiMeter
   end
 
   def amount_due
-    if @miles_driven >= 0.166666667
+    if @miles_driven >= one_sixth
       @amount_due += 250
     end
     if @airport

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -1,3 +1,5 @@
+require 'pry-debugger'
+
 class TaxiMeter
 
   attr_reader :start_time, :stop_time
@@ -23,15 +25,29 @@ class TaxiMeter
     @stop_time = Time.now
   end
 
-  def amount_due
-    if @stop_time.nil?
-      calculate_at_time = Time.now
-    else
-      calculate_at_time = @stop_time
+  def twilight_charge
+      if !@start_time.nil?
+        hour = @start_time.hour
+        if hour.between?( 21, 24) || hour.between?( 0, 4)
+          @amount_due += 100
+      end
     end
-    minutes = ((calculate_at_time - @start_time) / 60).ceil
-    charge_by_minutes = ((minutes * 0.49) * 100).floor
-    @amount_due += charge_by_minutes
+  end
+
+  def time_based_cost
+    if !@start_time.nil?
+      if @stop_time.nil?
+        calculate_at_time = Time.now
+      else
+        calculate_at_time = @stop_time
+      end
+      minutes = ((calculate_at_time - @start_time) / 60).ceil
+      charge_by_minutes = ((minutes * 0.49) * 100).floor
+      @amount_due += charge_by_minutes
+    end
+  end
+
+  def distance_based_cost
     if @miles_driven >= one_sixth
       @amount_due += 250
     end
@@ -40,11 +56,21 @@ class TaxiMeter
       current_mile_charge = ((num_of_charge_points * 0.40) * 100).floor
       @amount_due += current_mile_charge
     end
+  end
+
+  def airport_charge
     if @airport
       if @amount_due < 1310
         @amount_due = 1310
       end
     end
+  end
+
+  def amount_due
+    twilight_charge
+    time_based_cost
+    distance_based_cost
+    airport_charge
     @amount_due
   end
 end

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -24,7 +24,14 @@ class TaxiMeter
   end
 
   def amount_due
-
+    if @stop_time.nil?
+      calculate_at_time = Time.now
+    else
+      calculate_at_time = @stop_time
+    end
+    minutes = ((calculate_at_time - @start_time) / 60).ceil
+    charge_by_minutes = ((minutes * 0.49) * 100).floor
+    @amount_due += charge_by_minutes
     if @miles_driven >= one_sixth
       @amount_due += 250
     end

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -1,16 +1,25 @@
 class TaxiMeter
 
+  attr_reader :start_time, :stop_time
   attr_accessor :amount_due, :miles_driven
 
   def initialize
     @amount_due = 0
     @miles_driven = 0
+    @start_time = nil
+    @stop_time = nil
   end
 
   def one_sixth
     1.0 / 6.0
   end
 
+  def start
+    @start_time = Time.now
+  end
 
+  def stop
+    @stop_time = Time.now
+  end
 end
 

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -63,6 +63,7 @@ class TaxiMeter
   end
 
   def amount_due
+    @amount_due = 0
     if !@start_time.nil?
       twilight_charge
       time_based_cost

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -3,11 +3,12 @@ class TaxiMeter
   attr_reader :start_time, :stop_time
   attr_accessor :amount_due, :miles_driven
 
-  def initialize
+  def initialize(airport: false)
     @amount_due = 0
     @miles_driven = 0
     @start_time = nil
     @stop_time = nil
+    @airport = airport
   end
 
   def one_sixth
@@ -26,7 +27,12 @@ class TaxiMeter
     if @miles_driven >= 0.166666667
       @amount_due += 250
     end
-      @amount_due
+    if @airport
+      if @amount_due < 1310
+        @amount_due = 1310
+      end
+    end
+    @amount_due
   end
 end
 

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -1,4 +1,4 @@
-require 'pry-debugger'
+
 
 class TaxiMeter
 
@@ -35,24 +35,20 @@ class TaxiMeter
   end
 
   def time_based_cost
-    if !@start_time.nil?
-      if @stop_time.nil?
-        calculate_at_time = Time.now
-      else
-        calculate_at_time = @stop_time
-      end
-      minutes = ((calculate_at_time - @start_time) / 60).ceil
-      charge_by_minutes = ((minutes * 0.49) * 100).floor
-      @amount_due += charge_by_minutes
+    if @stop_time.nil?
+      calculate_at_time = Time.now
+    else
+      calculate_at_time = @stop_time
     end
+    minutes = ((calculate_at_time - @start_time) / 60).ceil
+    charge_by_minutes = (minutes * (2900.0 / 60.0)).ceil
+    @amount_due += charge_by_minutes
   end
 
   def distance_based_cost
-    if @miles_driven >= one_sixth
-      @amount_due += 250
-    end
+    @amount_due += 250
     if @miles_driven > one_sixth
-      num_of_charge_points = ((@miles_driven - one_sixth) / one_sixth).ceil
+      num_of_charge_points = ((@miles_driven - one_sixth) / one_sixth).round(3).ceil
       current_mile_charge = ((num_of_charge_points * 0.40) * 100).floor
       @amount_due += current_mile_charge
     end
@@ -67,10 +63,12 @@ class TaxiMeter
   end
 
   def amount_due
-    twilight_charge
-    time_based_cost
-    distance_based_cost
-    airport_charge
+    if !@start_time.nil?
+      twilight_charge
+      time_based_cost
+      distance_based_cost
+      airport_charge
+    end
     @amount_due
   end
 end

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -1,3 +1,16 @@
 class TaxiMeter
-  # TODO
+
+  attr_accessor :amount_due, :miles_driven
+
+  def initialize
+    @amount_due = 0
+    @miles_driven = 0
+  end
+
+  def one_sixth
+    1.0 / 6.0
+  end
+
+
 end
+

--- a/taxi_meter.rb
+++ b/taxi_meter.rb
@@ -24,8 +24,14 @@ class TaxiMeter
   end
 
   def amount_due
+
     if @miles_driven >= one_sixth
       @amount_due += 250
+    end
+    if @miles_driven > one_sixth
+      num_of_charge_points = ((@miles_driven - one_sixth) / one_sixth).ceil
+      current_mile_charge = ((num_of_charge_points * 0.40) * 100).floor
+      @amount_due += current_mile_charge
     end
     if @airport
       if @amount_due < 1310


### PR DESCRIPTION
my amount_due rounds up to the nearest cent in the taxis favor when calculating price by distance and price by time. Also as soon as start time is initialized price starts at 250, assuming a trip wouldn't be initialized without the intent to go somewhere.
